### PR TITLE
Let variable has to be assigned immediatly

### DIFF
--- a/expressions/variables.md
+++ b/expressions/variables.md
@@ -57,6 +57,14 @@ x = 5  // OK
 y = 6  // Error, y is let
 ```
 
+Using `let`instead of `var` also means the variable has to be assigned immediatly. 
+
+```pony
+let x: U32 = 3 // Ok 
+let y: U32 // Error, can't declare a let local without assigning to it
+y = 6 // Error, can't reassign to a let local
+```
+
 You never have to declare variables as `let`, but if you know you're never going to change a variable then using `let` is a good way to catch errors. It can also serve as a useful comment, indicating the value is not meant to be changed.
 
 ## Fields


### PR DESCRIPTION
From a small test I ran while learning pony, I first though I could do something like: 
```pony

let x: U32
x=4
```
I though this would be correct for as long as the expression `x= ` would only be used once (since the variable is declared using `let`). A quick compilation of my test showed I was wrong. Not only `let` variable could only be assigned once, they also have to be assigned immediatly. This is another difference compared to `var` declared variables.